### PR TITLE
adiciona endpoint para deletar evidencia

### DIFF
--- a/src/api/PoliceDepartment.EvidenceManager.API/DependencyInjection/BusinessRules/ApplicationExtensions.cs
+++ b/src/api/PoliceDepartment.EvidenceManager.API/DependencyInjection/BusinessRules/ApplicationExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using FluentValidation;
-using PoliceDepartment.EvidenceManager.Application.Authorization;
 using PoliceDepartment.EvidenceManager.Application.Authorization.UseCases;
 using PoliceDepartment.EvidenceManager.Application.Officer;
 using PoliceDepartment.EvidenceManager.Application.Officer.UseCases;
@@ -39,6 +38,7 @@ namespace PoliceDepartment.EvidenceManager.API.DependencyInjection.BusinessRules
             services.AddScoped<ICreateCase<CreateCaseViewModel, BaseResponse>, CreateCase>();
 
             services.AddScoped<IGetEvidenceById<BaseResponseWithValue<EvidenceViewModel>>, GetEvidenceById>();
+            services.AddScoped<IDeleteEvidence<BaseResponse>, DeleteEvidence>();
 
             services.AddScoped<IValidator<CreateCaseViewModel>, CaseValidator>();
 

--- a/src/api/PoliceDepartment.EvidenceManager.API/DependencyInjection/BusinessRules/IdentityExtensions.cs
+++ b/src/api/PoliceDepartment.EvidenceManager.API/DependencyInjection/BusinessRules/IdentityExtensions.cs
@@ -54,6 +54,7 @@ namespace PoliceDepartment.EvidenceManager.API.DependencyInjection.BusinessRules
                     IssuerSigningKey = new SymmetricSecurityKey(
                         Encoding.UTF8.GetBytes(configuration["Jwt:Key"]))
                 };
+                options.MapInboundClaims = false;
             });
 
             return services;

--- a/src/api/PoliceDepartment.EvidenceManager.Application/Authorization/AuthorizationExtensions.cs
+++ b/src/api/PoliceDepartment.EvidenceManager.Application/Authorization/AuthorizationExtensions.cs
@@ -6,7 +6,7 @@ namespace PoliceDepartment.EvidenceManager.Application.Authorization
     {
         public static Guid GetUserId(this ClaimsPrincipal userClaims)
         {
-            var userId = userClaims.Claims.First(i => i.Type == "UserId");
+            var userId = userClaims.Claims.First(i => i.Type == "sub");
 
             if(userId is null)
                 return Guid.Empty;

--- a/src/api/PoliceDepartment.EvidenceManager.Application/Evidence/UseCases/DeleteEvidence.cs
+++ b/src/api/PoliceDepartment.EvidenceManager.Application/Evidence/UseCases/DeleteEvidence.cs
@@ -1,14 +1,56 @@
-﻿using PoliceDepartment.EvidenceManager.Domain.Evidence.UseCases;
-using PoliceDepartment.EvidenceManager.SharedKernel;
+﻿using PoliceDepartment.EvidenceManager.Domain.Database;
+using PoliceDepartment.EvidenceManager.Domain.Evidence.UseCases;
+using PoliceDepartment.EvidenceManager.Domain.Exceptions;
+using PoliceDepartment.EvidenceManager.Domain.Logger;
 using PoliceDepartment.EvidenceManager.SharedKernel.Responses;
 
 namespace PoliceDepartment.EvidenceManager.API.Application.Evidence.UseCases
 {
     public class DeleteEvidence : IDeleteEvidence<BaseResponse>
     {
-        public Task<BaseResponse> RunAsync(Guid id, CancellationToken cancellationToken)
+        private readonly IUnitOfWork _uow;
+        private readonly BaseResponse _response;
+        private readonly ILoggerManager _logger;
+
+        public DeleteEvidence(IUnitOfWork uow, ILoggerManager logger)
         {
-            throw new NotImplementedException();
+            _uow = uow;
+            _response = new BaseResponse();
+            _logger = logger;
+        }
+        public async Task<BaseResponse> RunAsync(Guid id,Guid userId, CancellationToken cancellationToken)
+        {
+            _logger.LogDebug("Begin Delete evidence", ("id", id), ("userId", userId));
+
+            var evidence = await _uow.Evidence.GetByIdAsync(id, cancellationToken);
+
+            if(!evidence.Exists()){
+                _logger.LogWarning("Evidence doesn't exists to delete", ("id", id), ("userId", userId));
+
+                return _response.AsError(ResponseMessage.EvidenceDontExists);
+            }
+
+            var @case = await _uow.Case.GetByIdAsync(evidence.CaseId, cancellationToken);
+
+            if(@case.OfficerId != userId){
+                _logger.LogWarning("Officer is not the evidence owner", ("id", id), ("userId", userId));
+
+                return _response.AsError(ResponseMessage.Forbidden);
+            }
+
+            await _uow.BeginTransactionAsync(cancellationToken);
+
+            await _uow.Evidence.DeleteByIdAsync(evidence.Id);
+
+            if(!await _uow.SaveChangesAsync(cancellationToken) || !await _uow.CommmitAsync(cancellationToken)){
+                _logger.LogError("An error ocurred at the database", default, ("id", id), ("userId", userId));
+
+                throw new InfrastructureException("An unexpected error ocurred");
+            }
+
+            _logger.LogDebug("Success Delete evidence", ("id", id), ("userId", userId));
+
+            return _response.AsSuccess();
         }
     }
 }

--- a/src/api/PoliceDepartment.EvidenceManager.Domain/Evidence/UseCases/IDeleteEvidence.cs
+++ b/src/api/PoliceDepartment.EvidenceManager.Domain/Evidence/UseCases/IDeleteEvidence.cs
@@ -2,6 +2,6 @@
 {
     public interface IDeleteEvidence<TResult>
     {
-        Task<TResult> RunAsync(Guid id, CancellationToken cancellationToken);
+        Task<TResult> RunAsync(Guid id,Guid userId, CancellationToken cancellationToken);
     }
 }

--- a/src/api/PoliceDepartment.EvidenceManager.Infra/Database/Repositories/EvidenceRepository.cs
+++ b/src/api/PoliceDepartment.EvidenceManager.Infra/Database/Repositories/EvidenceRepository.cs
@@ -22,7 +22,9 @@ namespace PoliceDepartment.EvidenceManager.Infra.Database.Repositories
 
         public Task DeleteByIdAsync(Guid id)
         {
-            throw new NotImplementedException();
+            _context.Evidences.Remove(new EvidenceEntity { Id = id });
+
+            return Task.CompletedTask;
         }
 
         public async Task DeleteByCaseAsync(Guid caseId, CancellationToken cancellationToken)

--- a/tests/PoliceDepartment.EvidenceManager.UnitTests/Api/Evidence/DeleteEvidenceByIdTests.cs
+++ b/tests/PoliceDepartment.EvidenceManager.UnitTests/Api/Evidence/DeleteEvidenceByIdTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using NSubstitute;
+using PoliceDepartment.EvidenceManager.API.Application.Evidence.UseCases;
+using PoliceDepartment.EvidenceManager.Domain.Database;
+using PoliceDepartment.EvidenceManager.Domain.Evidence;
+using PoliceDepartment.EvidenceManager.Domain.Logger;
+using PoliceDepartment.EvidenceManager.SharedKernel.Responses;
+using PoliceDepartment.EvidenceManager.UnitTests.Fixtures.Api;
+
+namespace PoliceDepartment.EvidenceManager.UnitTests.Api.Evidence
+{
+    [Collection(nameof(ApiFixtureCollection))]
+    public class DeleteEvidenceByIdTests
+    {
+        private readonly ApiFixture _fixture;
+
+        public DeleteEvidenceByIdTests(ApiFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task RunAsyn_ValidEvidence_ShouldDelete()
+        {
+            //Arrange
+            var logger = Substitute.For<ILoggerManager>();
+            var uow = Substitute.For<IUnitOfWork>();
+
+            var id = Guid.NewGuid();
+            var officerId = Guid.NewGuid();
+            var evidenceEntity = _fixture.Evidence.GenerateSingleEntity();
+            var caseEntity = _fixture.Case.GenerateSingleEntity(officerId);
+
+            uow.Evidence.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(evidenceEntity));
+            uow.Case.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(caseEntity));
+            uow.SaveChangesAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+            uow.CommmitAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+
+            var sut = new DeleteEvidence(uow, logger);
+
+            //Act
+            var response = await sut.RunAsync(id,officerId, CancellationToken.None);
+
+            //Assert
+            response.Success.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        public async Task RunAsync_InvalidRequest_ShouldReturnErrorResponse(bool exists, bool isFromOfficerId)
+        {
+            //Arrange
+            var logger = Substitute.For<ILoggerManager>();
+            var uow = Substitute.For<IUnitOfWork>();
+
+            var id = Guid.NewGuid();
+            var officerId = Guid.NewGuid();
+
+            var evidenceEntity = _fixture.Evidence.GenerateSingleEntity();
+            var caseEntity = _fixture.Case.GenerateSingleEntity(isFromOfficerId ? officerId : Guid.Empty);
+
+            if (!exists)
+                evidenceEntity = new EvidenceEntity();
+
+            uow.Evidence.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(evidenceEntity));
+            uow.Case.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(caseEntity));
+
+            var sut = new DeleteEvidence(uow, logger);
+
+            //Act
+            var response = await sut.RunAsync(id, officerId, CancellationToken.None);
+
+            //Assert
+            response.Success.Should().BeFalse();
+
+            if(!exists)
+                response.ResponseMessageEqual(ResponseMessage.EvidenceDontExists);
+
+            if(!isFromOfficerId)
+                response.ResponseMessageEqual(ResponseMessage.Forbidden);
+
+        }
+        
+    }
+}

--- a/tests/PoliceDepartment.EvidenceManager.UnitTests/Api/Evidence/GetEvidenceByIdTests.cs
+++ b/tests/PoliceDepartment.EvidenceManager.UnitTests/Api/Evidence/GetEvidenceByIdTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using AutoMapper;
 using FluentAssertions;
 using NSubstitute;

--- a/tests/PoliceDepartment.EvidenceManager.UnitTests/Fixtures/Api/EvidenceFixture.cs
+++ b/tests/PoliceDepartment.EvidenceManager.UnitTests/Fixtures/Api/EvidenceFixture.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Bogus;
 using PoliceDepartment.EvidenceManager.Domain.Evidence;
 using PoliceDepartment.EvidenceManager.SharedKernel.ViewModels;


### PR DESCRIPTION
Precisei adicionar em IdentityExtensions.cs o "options.MapInboundClaims = false;" para conseguir obter o id do usuário no request pelo Token.

Não estava funcionando o GetById das ClaimsPrincipal para nenhuma rota que utilizava.

Validar se está correto agora.
